### PR TITLE
Fixes for Office 365 Outlook

### DIFF
--- a/office365/package.json
+++ b/office365/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "Zoho Mail",
+  "name": "Office365",
   "version": "1.0.0",
-  "description": "Outlook from Office365",
+  "description": "Outlook Office365",
   "main": "index.js",
   "author": "Chris Gray <chris.gray@amido.com>",
   "license": "MIT",

--- a/office365/webview.js
+++ b/office365/webview.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = (Franz, options) => {
   const getMessages = () => {
-    const unreadMail = jQuery("span[title*='Inbox'] + div > span").text();
+    const unreadMail = jQuery("span[title*='Inbox'] + div > span").first().text();
 
     Franz.setBadge(unreadMail);
   }


### PR DESCRIPTION
Doesn't do unread email numbers. I've not figured that out yet.

But it's a start.

This is different to the built-in outlook.com. Microsoft keeps those separate for some reason.
