### PR TITLE
Fix Mac syntax for plugin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The minimum requirement to run a custom Franz integration is Franz v. 4.0.0. To 
 ## Installation
 1. To install a new integration, download the integration folder e.g `oratio`.
 2. Open the Franz Plugins folder on your machine:
-  * Mac: `~Library/Application Support/Franz/Plugins/`
+  * Mac: `~/Library/Application\ Support/Franz/Plugins/`
   * Windows: `%appdata%/Franz/Plugins`
   * Linux: `~/.config/Franz/Plugins`
   * _Alternatively: Go to your Franz settings page, scroll down to the bottom and you will see an option to "Open the Franz plugin directory"_


### PR DESCRIPTION
Fixing Mac syntax for plugin directory so you can just copy and paste it.
Note: it might be interesting to also give this command somewhere if you just want all of them:
`git clone https://github.com/meetfranz/plugins.git ~/Library/Application\ Support/Franz/Plugins/`