### PR TITLE
googlevoice - fix badge to clear when there are no more unread messages

### DIFF
--- a/googlevoice/webview.js
+++ b/googlevoice/webview.js
@@ -2,7 +2,9 @@ module.exports = (Franz, options) => {
   function getMessages() {
     const count = document.querySelector('.msgCount').innerHTML.replace(/[\(\) ]/gi,"");
     if (count) {
-		Franz.setBadge(count);
+		  Franz.setBadge(count);
+    } else {
+      Franz.setBadge(0);
     }
   }
 


### PR DESCRIPTION
In the Google Voice UI, the message count (``document.querySelector('.msgCount')``) is an empty string if there are 0 new messages. With the current code, this means that the ``if (count) {`` branch is never executed... so the result is that the badge never goes away, because if you read all your messages the ``.msgCount`` div is completely empty.

This is a simple attempt to fix that; if the msgCount div empty, the message count should be 0, so ``setBadge(0)``.