### PR TITLE
Added badge counter

### DIFF
--- a/trello/webview.js
+++ b/trello/webview.js
@@ -1,3 +1,7 @@
 module.exports = (Franz, options) => {
-    
+  function getMessages() {
+    Franz.setBadge(document.querySelectorAll('.is-unread-notification').length);
+  }
+
+  Franz.loop(getMessages);
 }


### PR DESCRIPTION
It just count the amount of cards with a notification badge and not the actual number of notifications you got on every card