### PR TITLE
Facebook extension: Badge now displays friend requests and notifications

### DIFF
--- a/facebook/style.css
+++ b/facebook/style.css
@@ -1,0 +1,15 @@
+.fbChatSidebar {
+	display: none !important;
+}
+
+.fbDock {
+	display: none !important;
+}
+
+.ego_column {
+	display: none !important;
+}
+
+[role=navigation] > div:nth-child(2) > div:nth-child(2){
+	display: none !important;
+}

--- a/facebook/webview.js
+++ b/facebook/webview.js
@@ -1,3 +1,16 @@
 module.exports = (Franz, options) => {
-    
+	const path = require('path');
+
+	// inject a single css file
+	Franz.injectCSS(path.join(__dirname, 'style.css'));
+
+	function getMessages() {
+		var notifications = document.querySelectorAll("#notificationsCountValue")[0];
+		var friendRequests = document.querySelectorAll("#requestsCountValue")[0];
+		
+		counter = parseInt(notifications.innerText) + parseInt(friendRequests.innerText);
+		Franz.setBadge(counter);
+	};
+
+	Franz.loop(getMessages);
 }


### PR DESCRIPTION
Before, the facebook extension did not show if there were any notifications. This has been taken care of.

Also added a CSS file which hides chat and the message button in the top row, that latter might break in the future because of pretty wonky CSS selectors.

Is this how you do a pull request (never done that before)? 😄 