### PR TITLE
Update RocketChat plugin for 0.52 API

### DIFF
--- a/rocketchat/index.js
+++ b/rocketchat/index.js
@@ -4,7 +4,7 @@ module.exports = (Franz) => {
       const api = `${URL}/api/info`;
       return new Promise((resolve, reject) => {
         $.get(api, (resp) => {
-          if (typeof(resp) === 'object' && 'build' in resp) {
+          if (typeof(resp) === 'object' && ('build' in resp || 'version' in resp)) {
             resolve();
           } else {
             reject();


### PR DESCRIPTION
From RocketChat 0.52 onwards the result of the info api is as follows, and does not include a `build` member:
```
{
  "version": "0.52.0",
  "success": true
}
```