### PR TITLE
Badge icon should include count from notifications panel

### DIFF
--- a/office365/webview.js
+++ b/office365/webview.js
@@ -2,9 +2,18 @@ const path = require('path');
 
 module.exports = (Franz, options) => {
   const getMessages = () => {
-    const unreadMail = jQuery("span[title*='Inbox'] + div > span").first().text();
+    unreadMail = parseInt(jQuery("span[title*='Inbox'] + div > span").first().text());
+    notifications = parseInt(jQuery("div[class*='o365cs-flexPane-unseenitems']").text().trim());
 
-    Franz.setBadge(unreadMail);
+    badgeCount = 0
+    if (Number.isInteger(notifications)) {
+      badgeCount += notifications
+    }
+    if (Number.isInteger(unreadMail)) {
+      badgeCount += unreadMail
+    }
+
+    Franz.setBadge(badgeCount);
   }
 
   Franz.loop(getMessages);


### PR DESCRIPTION
Adds support for incrementing the badge count based on the count of items in the notification panel. This tells you if you have tasks due or meetings coming up.