### PR TITLE
Fix doc of configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ If your service works with custom URLs, just leave this empty.
 }
 ```
 <br />
+
 ```json
 {
     "serviceURL": "https://{teamID}.slack.com"


### PR DESCRIPTION
I fixed the broken markdown (GFM) format in configuration.md !

(it is the under of `[string] serviceURL` in [here](https://github.com/meetfranz/plugins/blob/da8c6ec7cb9b0bb0076da1c3ff2b2204d0b79e2a/docs/configuration.md))