### PR TITLE
Fix typo in docs/integration.md

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -15,7 +15,7 @@ A Franz recipe is basically nothing else than a node module and is currently ini
 ## Installation
 1. To install a new integration, download the integration folder e.g `whatsapp`.
 2. Open the Franz Plugins folder on your machine:
-  * Mac: `~Library/Application Support/Franz/recipes/dev/`
+  * Mac: `~/Library/Application Support/Franz/recipes/dev/`
   * Windows: `%appdata%/Franz/recipes/dev/`
 3. Copy the `whatsapp` folder into the plugins directory
 4. Reload Franz


### PR DESCRIPTION
Replace
* Mac: `~Library/Application Support/Franz/recipes/dev/`

With
* Mac: `~/Library/Application Support/Franz/recipes/dev/`

Signed-off-by: Alberto Murillo <albertomurillosilva@gmail.com>