### PR TITLE
Remove icon.png from example plugin structure

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -25,7 +25,6 @@ Every recipe needs a specific file structure in order to be detected as a Franz 
 
 * recipes/dev/`[NAME]`/
   * icon.svg
-  * icon.png
   * index.js
   * package.json
   * webview.js


### PR DESCRIPTION
Unless there's a reason for needing icon.png listed (note that the official plugins do not usually have this file), I think we should remove this.