### PR TITLE
fixed path

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -16,7 +16,7 @@ A Franz recipe is basically nothing else than a node module and is currently ini
 1. To install a new integration, download the integration folder e.g `whatsapp`.
 2. Open the Franz Plugins folder on your machine (note that this `dev` directory may not exist yet, and you must create it):
   * Mac: `~/Library/Application Support/Franz/recipes/dev/`
-  * Windows: `%appdata%/Roaming/Franz/recipes/dev/`
+  * Windows: `%appdata%/Franz/recipes/dev/`
   * Linux: `~/.config/Franz/recipes/dev`
 3. Copy the `whatsapp` folder into the plugins directory
 4. Reload Franz


### PR DESCRIPTION
%APPDATA% == C:\Users\%UserName%\AppData\Roaming
Fix
"%APPDATA%\Roaming\Franz\recipes\dev" is incorrectly
correctly "%APPDATA%\Franz\recipes\dev"