### PR TITLE
Add Zalo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ __To add a new service:__
 * [WeChat](https://github.com/BrianGilbert/franz-recipe-wechat)
 * [WhatsApp](https://github.com/meetfranz/recipe-whatsapp)
 * [Zulip](https://github.com/adambirds/recipe-zulip)
+* [Zalo](https://github.com/huychau/franz-zalo)
 
 ## :rotating_light: Important notice
 Franz 4 plugins are __not necessarily compatible__ with Franz 5. Please help us to port the [legacy recipes](https://github.com/meetfranz/plugins-legacy) to Franz 5.


### PR DESCRIPTION
[Zalo](https://chat.zalo.me/) is a free messaging and calling application that works on mobile and desktop platforms, used in Vietnam, USA, Myanmar, Japan, Taiwan, South Korea, Malaysia, Saudi Arabia. Australia, Angola, Sri Lanka, Czech Republic, etc.

This repo is a new implementation Zalo with Franz. It worked on the lastest Zalo version.