### PR TITLE
Add link to Wire recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ __To add a new service:__
 * [Watson Workspace](https://github.com/edm00se/franz-recipe-watson-workspace)
 * [WeChat](https://github.com/BrianGilbert/franz-recipe-wechat)
 * [WhatsApp](https://github.com/meetfranz/recipe-whatsapp)
+* [Wire](https://gitlab.com/sckreuzlingen/franz-recipe-wire)
 * [Zulip](https://github.com/adambirds/recipe-zulip)
 
 ## :rotating_light: Important notice


### PR DESCRIPTION
Adds a link to the community-contributed Franz recipe for Wire. https://app.wire.com